### PR TITLE
fix: use cleaned name for QSettings delete and rename operations

### DIFF
--- a/dialogs/server_config_dialog.py
+++ b/dialogs/server_config_dialog.py
@@ -321,11 +321,13 @@ class ServerConfigDialog(BASE, WIDGET):
             bool: True if the name is valid, False otherwise.
         """
         saved_config_names = list_qgs_settings_child_groups(f'{PLUGIN_SETTINGS_SERVER_CONFIG_KEY}/connection')
-        if self.mode == 'edit' and config_name_from_formular not in saved_config_names:
+        clean_form_name = ServerConfig.clean_name_for_storage(config_name_from_formular)
+        if self.mode == 'edit' and clean_form_name not in saved_config_names:
             s = QSettings()
-            s.remove(f"{PLUGIN_SETTINGS_SERVER_CONFIG_KEY}/connection/{self.selected_server_config_name}")
+            clean_selected = ServerConfig.clean_name_for_storage(self.selected_server_config_name)
+            s.remove(f"{PLUGIN_SETTINGS_SERVER_CONFIG_KEY}/connection/{clean_selected}")
             return True
-        if config_name_from_formular in saved_config_names and self.mode != 'edit':
+        if clean_form_name in saved_config_names and self.mode != 'edit':
             show_fail_box('Failed', 'Server configuration name already exists')
             return False
         return True

--- a/main_dialog.py
+++ b/main_dialog.py
@@ -325,7 +325,8 @@ class MainDialog(BASE, WIDGET):
                     selected_server_config=selected_server_config)) != QMessageBox.StandardButton.Yes:
             return
         s = QSettings()
-        s.remove(f"{PLUGIN_SETTINGS_SERVER_CONFIG_KEY}/connection/{selected_server_config}")
+        clean_name = ServerConfig.clean_name_for_storage(selected_server_config)
+        s.remove(f"{PLUGIN_SETTINGS_SERVER_CONFIG_KEY}/connection/{clean_name}")
         show_success_box(self.tr('Success'),
                          self.tr('Server configuration successfully removed'))
         self.update_server_table()


### PR DESCRIPTION
The clean_name_for_storage() introduced in PR #27 was not applied in on_remove_server_config_clicked and checkConfigName, causing deletions and renames to fail when the stored key differs from the displayed original name.